### PR TITLE
feat: módulo de relatórios (métricas de campanhas)

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -622,6 +622,136 @@ const swaggerDocument = {
         },
       },
     },
+    "/relatorios": {
+      post: {
+        summary: "Criar relatório",
+        description:
+          "Cria um novo relatório (métrica de campanha) com informações de aberturas, cliques e rejeições, vinculadas a uma campanha. Requer autenticação.",
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  campanhaId: { type: "string", example: "uuid-campanha" },
+                  aberturas: { type: "number", example: 100 },
+                  cliques: { type: "number", example: 50 },
+                  rejeicoes: { type: "number", example: 10 },
+                  timestamp: { type: "string", format: "date-time", example: "2023-12-31T23:59:59Z" }
+                },
+                required: ["campanhaId", "aberturas", "cliques", "rejeicoes"],
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "Relatório criado com sucesso." },
+          "400": { description: "Dados inválidos." },
+          "401": { description: "Não autorizado." },
+          "500": { description: "Erro interno no servidor." },
+        },
+      },
+      get: {
+        summary: "Listar relatórios",
+        description: "Retorna uma lista de todos os relatórios de campanhas. Requer autenticação.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": {
+            description: "Lista de relatórios.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Relatorio" },
+                },
+              },
+            },
+          },
+          "401": { description: "Não autorizado." },
+          "500": { description: "Erro interno no servidor." },
+        },
+      },
+    },
+    "/relatorios/{id}": {
+      get: {
+        summary: "Obter relatório por ID",
+        description: "Recupera os detalhes de um relatório específico. Requer autenticação.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            description: "ID do relatório",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": { description: "Detalhes do relatório." },
+          "404": { description: "Relatório não encontrado." },
+          "401": { description: "Não autorizado." },
+          "500": { description: "Erro interno no servidor." },
+        },
+      },
+      patch: {
+        summary: "Atualizar relatório",
+        description: "Atualiza os dados de um relatório existente. Requer autenticação.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            description: "ID do relatório a ser atualizado",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  campanhaId: { type: "string" },
+                  aberturas: { type: "number" },
+                  cliques: { type: "number" },
+                  rejeicoes: { type: "number" },
+                  timestamp: { type: "string", format: "date-time" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Relatório atualizado com sucesso." },
+          "400": { description: "Dados inválidos." },
+          "401": { description: "Não autorizado." },
+          "500": { description: "Erro interno no servidor." },
+        },
+      },
+      delete: {
+        summary: "Remover relatório",
+        description: "Remove um relatório existente. Requer autenticação.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            description: "ID do relatório a ser removido",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": { description: "Relatório removido com sucesso." },
+          "401": { description: "Não autorizado." },
+          "500": { description: "Erro interno no servidor." },
+        },
+      },
+    },
   },
   components: {
     securitySchemes: {
@@ -648,6 +778,17 @@ const swaggerDocument = {
           camposCustom: { type: "object" },
           criadoEm: { type: "string", format: "date-time" },
           atualizadoEm: { type: "string", format: "date-time" },
+        },
+      },
+      Relatorio: {
+        type: "object",
+        properties: {
+          id: { type: "string", example: "uuid-relatorio" },
+          campanhaId: { type: "string", example: "uuid-campanha" },
+          aberturas: { type: "number", example: 100 },
+          cliques: { type: "number", example: 50 },
+          rejeicoes: { type: "number", example: 10 },
+          timestamp: { type: "string", format: "date-time", example: "2023-12-31T23:59:59Z" },
         },
       },
     },

--- a/src/controllers/relatorioController.ts
+++ b/src/controllers/relatorioController.ts
@@ -1,0 +1,97 @@
+//relatorioController.ts
+
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import {
+  createRelatorio,
+  getRelatorios,
+  getRelatorioById,
+  updateRelatorio,
+  deleteRelatorio,
+} from '../services/relatorioService';
+
+const relatorioSchema = z.object({
+  campanhaId: z.string(),
+  aberturas: z.number(),
+  cliques: z.number(),
+  rejeicoes: z.number(),
+  timestamp: z.preprocess((arg) => (arg ? new Date(arg as string) : undefined), z.date().optional()),
+});
+
+export const createRelatorioController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const data = relatorioSchema.parse(req.body);
+    const relatorio = await createRelatorio(data);
+    res.status(201).json({ message: 'Relatório criado com sucesso!', relatorio });
+    return;
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: 'Dados inválidos', issues: error.errors, docs: '/api-docs/errors#createRelatorio' });
+      return;
+    }
+    console.error(error);
+    res.status(500).json({ error: 'Erro ao criar relatório.', docs: '/api-docs/errors#createRelatorio' });
+    return;
+  }
+};
+
+export const getRelatoriosController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const relatorios = await getRelatorios();
+    res.status(200).json(relatorios);
+    return;
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Erro ao obter relatórios.', docs: '/api-docs/errors#getRelatorios' });
+    return;
+  }
+};
+
+export const getRelatorioByIdController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const relatorio = await getRelatorioById(id);
+    if (!relatorio) {
+      res.status(404).json({ error: 'Relatório não encontrado.', docs: '/api-docs/errors#getRelatorioById' });
+      return;
+    }
+    res.status(200).json(relatorio);
+    return;
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Erro ao obter relatório.', docs: '/api-docs/errors#getRelatorioById' });
+    return;
+  }
+};
+
+export const updateRelatorioController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const data = relatorioSchema.partial().parse(req.body);
+    const relatorio = await updateRelatorio(id, data);
+    res.status(200).json({ message: 'Relatório atualizado com sucesso!', relatorio });
+    return;
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: 'Dados inválidos', issues: error.errors, docs: '/api-docs/errors#updateRelatorio' });
+      return;
+    }
+    console.error(error);
+    res.status(500).json({ error: 'Erro ao atualizar relatório.', docs: '/api-docs/errors#updateRelatorio' });
+    return;
+  }
+};
+
+export const deleteRelatorioController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    await deleteRelatorio(id);
+    res.status(200).json({ message: 'Relatório removido com sucesso!' });
+    return;
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Erro ao remover relatório.', docs: '/api-docs/errors#deleteRelatorio' });
+    return;
+  }
+};
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 //index.ts
+
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
@@ -9,6 +10,7 @@ import authRoutes from './routes/authRoutes';
 import leadRoutes from './routes/leadRoutes';
 import integracaoRoutes from './routes/integracaoRoutes';
 import campanhaRoutes from './routes/campanhaRoutes';
+import relatorioRoutes from './routes/relatorioRoutes';
 import passwordResetRoutes from './routes/passwordResetRoutes';
 import userRoutes from './routes/userRoutes';
 import { errorHandler } from './middlewares/errorHandler';
@@ -26,6 +28,7 @@ app.use('/auth', authRoutes);
 app.use('/leads', leadRoutes);
 app.use('/integracoes', integracaoRoutes);
 app.use('/campanhas', campanhaRoutes);
+app.use('/relatorios', relatorioRoutes);
 app.use('/password-reset', passwordResetRoutes);
 app.use('/usuarios', userRoutes);
 

--- a/src/routes/relatorioRoutes.ts
+++ b/src/routes/relatorioRoutes.ts
@@ -1,0 +1,22 @@
+//relatorioRoutes.ts
+
+import { Router } from 'express';
+import {
+  createRelatorioController,
+  getRelatoriosController,
+  getRelatorioByIdController,
+  updateRelatorioController,
+  deleteRelatorioController,
+} from '../controllers/relatorioController';
+import { authenticate } from '../middlewares/authMiddleware';
+
+const router = Router();
+
+router.post('/', authenticate, createRelatorioController);
+router.get('/', authenticate, getRelatoriosController);
+router.get('/:id', authenticate, getRelatorioByIdController);
+router.patch('/:id', authenticate, updateRelatorioController);
+router.delete('/:id', authenticate, deleteRelatorioController);
+
+export default router;
+

--- a/src/services/relatorioService.ts
+++ b/src/services/relatorioService.ts
@@ -1,0 +1,52 @@
+//relatorioService.ts
+
+import prisma from '../config/database';
+
+export interface RelatorioData {
+  campanhaId: string;
+  aberturas: number;
+  cliques: number;
+  rejeicoes: number;
+  timestamp?: Date;
+}
+
+export const createRelatorio = async (data: RelatorioData) => {
+  const relatorio = await prisma.metricaCampanha.create({
+    data: {
+      campanhaId: data.campanhaId,
+      aberturas: data.aberturas,
+      cliques: data.cliques,
+      rejeicoes: data.rejeicoes,
+      timestamp: data.timestamp ?? new Date(),
+    },
+  });
+  return relatorio;
+};
+
+export const getRelatorios = async () => {
+  const relatorios = await prisma.metricaCampanha.findMany();
+  return relatorios;
+};
+
+export const getRelatorioById = async (id: string) => {
+  const relatorio = await prisma.metricaCampanha.findUnique({
+    where: { id },
+  });
+  return relatorio;
+};
+
+export const updateRelatorio = async (id: string, data: Partial<RelatorioData>) => {
+  const relatorio = await prisma.metricaCampanha.update({
+    where: { id },
+    data,
+  });
+  return relatorio;
+};
+
+export const deleteRelatorio = async (id: string) => {
+  const relatorio = await prisma.metricaCampanha.delete({
+    where: { id },
+  });
+  return relatorio;
+};
+


### PR DESCRIPTION
### Descrição

Este pull request implementa o módulo de relatórios (métricas de campanhas), permitindo gerenciar dados como aberturas, cliques e rejeições associados às campanhas. As principais funcionalidades adicionadas incluem:

1. **Criação de Relatórios**:
   - Endpoint: `POST /relatorios`
   - Validação dos dados utilizando Zod.
   - Permite registrar métricas como aberturas, cliques e rejeições vinculadas a uma campanha.

2. **Listagem de Relatórios**:
   - Endpoint: `GET /relatorios`
   - Retorna todos os relatórios cadastrados.

3. **Detalhes de um Relatório**:
   - Endpoint: `GET /relatorios/:id`
   - Retorna informações completas sobre um relatório específico.

4. **Atualização de Relatórios**:
   - Endpoint: `PATCH /relatorios/:id`
   - Permite atualizar campos específicos (ex.: cliques ou rejeições).

5. **Exclusão de Relatórios**:
   - Endpoint: `DELETE /relatorios/:id`
   - Remove um relatório do banco de dados.

6. **Documentação Interativa**:
   - Atualização da documentação Swagger com exemplos detalhados para todos os endpoints acima.
   - Respostas documentadas para todos os cenários (sucesso, erros 400, 404 e 500).

### Testes Realizados

- Testes manuais realizados utilizando Postman:
  - Criação, listagem, atualização e exclusão de relatórios.
  - Testes com dados válidos e inválidos para validação das respostas.

### Como Testar

1. Inicie o servidor localmente:
``
npm run dev
``
2. Acesse os endpoints abaixo utilizando Postman ou outra ferramenta:
- `POST /relatorios`: Envie um JSON com `campanhaId`, `aberturas`, `cliques` e `rejeicoes`.
- `GET /relatorios`: Liste todos os relatórios cadastrados.
- `PATCH /relatorios/:id`: Atualize informações específicas de um relatório.
- `DELETE /relatorios/:id`: Exclua um relatório pelo ID.